### PR TITLE
fix CVE-2021-33430, up req numpy>=1.21

### DIFF
--- a/dags/requirements.txt
+++ b/dags/requirements.txt
@@ -11,6 +11,6 @@ urllib3==1.26.7
 tenacity==8.0.1
 requests==2.26.0
 geopy==2.2.0
-numpy==1.20.3
+numpy>=1.21
 pandas==1.3.5
 clickhouse-driver==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ urllib3==1.26.7
 tenacity==8.0.1
 requests==2.26.0
 geopy==2.2.0
-numpy==1.20.3
+numpy>=1.21
 pandas==1.3.5
 clickhouse-driver==0.2.2


### PR DESCRIPTION
Remediation
Upgrade numpy to version 1.21 or later. For example:

numpy>=1.21
Always verify the validity and compatibility of suggestions with your codebase.

CVE-2021-33430
Vulnerable versions: >= 1.9.0, < 1.21
Patched version: 1.21
A Buffer Overflow vulnerability exists in NumPy 1.9.x in the PyArray_NewFromDescr_int function of ctors.c when specifying arrays of large dimensions (over 32) from Python code, which could let a malicious user cause a Denial of Service.