### PR TITLE
在github上查询的profile中增加根据profile推断的字段再将其存入opensearch

### DIFF
--- a/dags/oss_know/libs/github/sync_profiles.py
+++ b/dags/oss_know/libs/github/sync_profiles.py
@@ -1,7 +1,8 @@
 import datetime
 import itertools
 import requests
-from oss_know.libs.util.base import get_opensearch_client, get_redis_client, infer_info_insert_into_profile
+from oss_know.libs.util.base import get_opensearch_client, get_redis_client, \
+    infer_country_company_geo_insert_into_profile
 from oss_know.libs.util.github_api import GithubAPI
 from oss_know.libs.base_dict.opensearch_index import OPENSEARCH_INDEX_GITHUB_PROFILE, OPENSEARCH_INDEX_CHECK_SYNC_DATA
 from oss_know.libs.base_dict.redis import STORAGE_HASH, STORAGE_IDS_SET, WORKING_HASH
@@ -89,12 +90,7 @@ def sync_github_profiles(github_tokens, opensearch_conn_info, redis_client_info,
                                                                          user_id=storage_id)
             latest_profile_updated_at = latest_github_profile["updated_at"]
             if storage_updated_at != latest_profile_updated_at:
-                try:
-                    infer_info_insert_into_profile(latest_github_profile)
-                except Exception as e:
-                    logger.error(
-                        f"Failed to infer info insert into profile when sync github profiles,the exception message: {e}，"
-                        f"the type of exception: {type(e)}")
+                infer_country_company_geo_insert_into_profile(latest_github_profile)
                 opensearch_client.index(index=OPENSEARCH_INDEX_GITHUB_PROFILE,
                                         body={"search_key": {
                                             'updated_at': (datetime.datetime.now().timestamp() * 1000)},

--- a/dags/oss_know/libs/github/sync_profiles.py
+++ b/dags/oss_know/libs/github/sync_profiles.py
@@ -1,7 +1,7 @@
 import datetime
 import itertools
 import requests
-from oss_know.libs.util.base import get_opensearch_client, get_redis_client, infer_country_insert_into_profile
+from oss_know.libs.util.base import get_opensearch_client, get_redis_client, infer_info_insert_into_profile
 from oss_know.libs.util.github_api import GithubAPI
 from oss_know.libs.base_dict.opensearch_index import OPENSEARCH_INDEX_GITHUB_PROFILE, OPENSEARCH_INDEX_CHECK_SYNC_DATA
 from oss_know.libs.base_dict.redis import STORAGE_HASH, STORAGE_IDS_SET, WORKING_HASH
@@ -89,7 +89,12 @@ def sync_github_profiles(github_tokens, opensearch_conn_info, redis_client_info,
                                                                          user_id=storage_id)
             latest_profile_updated_at = latest_github_profile["updated_at"]
             if storage_updated_at != latest_profile_updated_at:
-                infer_country_insert_into_profile(latest_github_profile)
+                try:
+                    infer_info_insert_into_profile(latest_github_profile)
+                except Exception as e:
+                    logger.error(
+                        f"Failed to infer info insert into profile when sync github profiles,the exception message: {e}，"
+                        f"the type of exception: {type(e)}")
                 opensearch_client.index(index=OPENSEARCH_INDEX_GITHUB_PROFILE,
                                         body={"search_key": {
                                             'updated_at': (datetime.datetime.now().timestamp() * 1000)},

--- a/dags/oss_know/libs/util/base.py
+++ b/dags/oss_know/libs/util/base.py
@@ -1,5 +1,6 @@
 import re
 
+import geopy as geopy
 import redis
 import requests
 import urllib3
@@ -110,15 +111,19 @@ def infer_country_from_location(github_location):
 
 def infer_all_info_from_location(github_location):
     """
-    :param  github_location: location from a GitHub profile
-    :return address  : raw address message got from GoogleV3API, return a string containing city, country and so on
+    :param  githubLocation: the location given by github
+    :return GoogleGeoInfo  : the information of GoogleGeo inferred by location
     """
     from airflow.models import Variable
     api_token = Variable.get(LOCATIONGEO_TOKEN, deserialize_json=True)
     geolocator = GoogleV3(api_key=api_token)
-    geo_res = geolocator.geocode(github_location, language='en')
-    if geo_res:
-        return geo_res.address
+    geo_res = geolocator.geocode(githubLocation, language='en')
+    if geo_res and geo_res.raw["address_components"]:
+        address_components = geo_res.raw["address_components"]
+        all_info_from_location = {}
+        for address_component in address_components:
+            all_info_from_location[address_component["types"][0]] = address_component["long_name"]
+        return all_info_from_location
     return None
 
 
@@ -145,26 +150,26 @@ def infer_final_company_from_company(company):
         return company_country[company][1]
     return None
 
-
 inferrers = [
-        ("country_inferred_from_email_cctld", "email", infer_country_from_emailcctld),
-        ("country_inferred_from_email_domain_company", "email", infer_country_from_emaildomain),
-        ("country_inferred_from_location", "location", infer_country_from_location),
-        ("country_inferred_from_company", "company", infer_country_from_company),
-        ("final_company_inferred_from_company", "company", infer_final_company_from_company),
-        ("company_inferred_from_email_domain_company", "email", infer_company_from_emaildomain),
-        ("inferred_from_location", "location", infer_all_info_from_location)
-    ]
+    ("country_inferred_from_email_cctld", "email", infer_country_from_emailcctld),
+    ("country_inferred_from_email_domain_company", "email", infer_country_from_emaildomain),
+    ("country_inferred_from_location", "location", infer_country_from_location),
+    ("country_inferred_from_company", "company", infer_country_from_company),
+    ("company_inferred_from_email_domain_company", "email", infer_company_from_emaildomain),
+    ("inferred_from_location", "location", infer_all_info_from_location),
+    ("final_company_inferred_from_company", "company", infer_final_company_from_company)
+]
 
 
-def infer_country_insert_into_profile(latest_github_profile):
+def infer_info_insert_into_profile(latest_github_profile):
     try:
         for tup in inferrers:
             key, original_key, infer = tup
             original_property = latest_github_profile[original_key]
             latest_github_profile[key] = infer(original_property) if original_property else None
 
-    except (urllib3.exceptions.MaxRetryError, requests.exceptions.ProxyError) as error:
-        logger.error(f"error occurs when inferring country, {error}")
+    except (urllib3.exceptions.MaxRetryError, requests.exceptions.ProxyError, geopy.exc.GeocoderQueryError) as e:
+        logger.error(
+            f"error occurs when inferring information by github profile, exception message: {e},the type of exception: {type(e)}")
         for inferrer in inferrers:
             latest_github_profile[inferrer[0]] = None

--- a/dags/oss_know/libs/util/opensearch_api.py
+++ b/dags/oss_know/libs/util/opensearch_api.py
@@ -15,7 +15,7 @@ import requests
 from oss_know.libs.util.airflow import get_postgres_conn
 from oss_know.libs.util.log import logger
 from oss_know.libs.util.github_api import GithubAPI
-from oss_know.libs.util.base import infer_info_insert_into_profile
+from oss_know.libs.util.base import infer_country_company_geo_insert_into_profile, inferrers
 
 from oss_know.libs.base_dict.opensearch_index import OPENSEARCH_INDEX_GITHUB_COMMITS, OPENSEARCH_INDEX_GITHUB_ISSUES, \
     OPENSEARCH_INDEX_GITHUB_ISSUES_TIMELINE, OPENSEARCH_INDEX_GITHUB_ISSUES_COMMENTS, \
@@ -144,19 +144,10 @@ class OpensearchAPI:
                 latest_github_profile = github_api.get_latest_github_profile(http_session=session,
                                                                              github_tokens_iter=github_tokens_iter,
                                                                              user_id=github_id)
-                latest_github_profile["country_inferred_from_email_cctld"] = None
-                latest_github_profile["country_inferred_from_email_domain_company"] = None
-                latest_github_profile["country_inferred_from_location"] = None
-                latest_github_profile["country_inferred_from_company"] = None
-                latest_github_profile["company_inferred_from_email_domain_company"] = None
-                latest_github_profile["inferred_from_location"] = None
-                latest_github_profile["company_inferred_from_existed_profile_company"] = None
-                try:
-                    infer_info_insert_into_profile(latest_github_profile)
-                except Exception as e:
-                    logger.error(
-                        f"Failed to infer info insert into profile when init github profiles,the exception message: {e}，"
-                        f"the type of exception: {type(e)}")
+                for tup in inferrers:
+                    key, original_key, infer = tup
+                    latest_github_profile[key] = None
+                infer_country_company_geo_insert_into_profile(latest_github_profile)
                 opensearch_client.index(index=OPENSEARCH_INDEX_GITHUB_PROFILE,
                                         body={"search_key": {
                                             'updated_at': int(datetime.datetime.now().timestamp() * 1000)},

--- a/dags/oss_know/oss_know_dags/dags_github/dag_github_init_profiles.py
+++ b/dags/oss_know/oss_know_dags/dags_github/dag_github_init_profiles.py
@@ -41,17 +41,13 @@ with DAG(
         repo = params["repo"]
         init_ids = init_profiles.load_github_ids_by_repo(opensearch_conn_infos, owner, repo)
         kwargs['ti'].xcom_push(key=f'{owner}_{repo}_ids', value=init_ids)
-        # todo: need clean just for test
-        # github_tokens = Variable.get("github_tokens", deserialize_json=True)
-        # do_add_updated_github_profiles = sync_profiles.add_updated_github_profiles(github_tokens,
-        # opensearch_conn_infos)
 
 
     def load_github_repo_profiles(params, **kwargs):
         from airflow.models import Variable
         github_tokens = Variable.get("github_tokens", deserialize_json=True)
         opensearch_conn_infos = Variable.get("opensearch_conn_data", deserialize_json=True)
-        github_users_ids =[]
+        github_users_ids = []
         for param in params:
             owner = param["owner"]
             repo = param["repo"]


### PR DESCRIPTION
1、在init_profiles中先增加新的7个推断字段并设置初始值，保证即使标题业务出现异常，存入到opensearch中的profile格式一致；
2、增加标题业务处理的异常类型：geopy.exc.GeocoderQueryError；
3、在init_profiles以及sync_profiles的过程中对标题业务进行进一步异常处理，增强代码健壮性，标题业务出现异常不影响原本的profile的初始化和更新操作；
4、对通过GoogleGeoApi查询出的地理信息进行拆解后存到“inferred_from_location”字段中；
5、与晨琪对接base中的infer_company_from_existed_profile_company功能。