### PR TITLE
Init profile with proxy

### DIFF
--- a/dags/oss_know/libs/exceptions/__init__.py
+++ b/dags/oss_know/libs/exceptions/__init__.py
@@ -1,0 +1,10 @@
+class GithubAPIException(Exception):
+    def __init__(self, message, status):
+        super().__init__(message, status)
+        self.message = message
+        self.status = status
+
+
+class GithubNonExistingUserError(GithubAPIException):
+    pass
+

--- a/dags/oss_know/libs/exceptions/__init__.py
+++ b/dags/oss_know/libs/exceptions/__init__.py
@@ -5,6 +5,6 @@ class GithubAPIException(Exception):
         self.status = status
 
 
-class GithubNonExistingUserError(GithubAPIException):
+class GithubResourceNotFoundError(GithubAPIException):
     pass
 

--- a/dags/oss_know/libs/github/init_profiles.py
+++ b/dags/oss_know/libs/github/init_profiles.py
@@ -18,7 +18,6 @@ def load_github_ids_by_repo(opensearch_conn_infos, owner, repo):
 
 def load_ids_from_commits(opensearch_client, owner, repo):
     """Get GitHub users' ids from GitHub commits."""
-    logger.debug(f'calling load_ids_by_github_commits for {owner}/{repo}')
     res = get_profiles_from_os(opensearch_client, owner, repo,
                                index=OPENSEARCH_INDEX_GITHUB_COMMITS)
     if not res:
@@ -98,13 +97,11 @@ def get_profiles_from_os(opensearch_client, owner, repo, index):
     return res
 
 
-def load_github_profiles(github_tokens, opensearch_conn_infos, github_users_ids):
+def load_github_profiles(token_proxy_accommodator, opensearch_conn_infos, github_users_ids):
     """Get GitHub profiles by ids."""
-    logger.debug(f'calling load_github_profiles by {github_users_ids}')
     # get ids set;
-    github_users_ids = list(set(github_users_ids))
+    # github_users_ids = list(set(github_users_ids))
     # put GitHub user profile into opensearch if it is not in opensearch
-    github_tokens_iter = itertools.cycle(github_tokens)
     opensearch_api = OpensearchAPI()
-    opensearch_api.put_profile_into_opensearch(github_ids=github_users_ids, github_tokens_iter=github_tokens_iter,
+    opensearch_api.put_profile_into_opensearch(github_ids=github_users_ids, token_proxy_accommodator=token_proxy_accommodator,
                                                opensearch_client=get_opensearch_client(opensearch_conn_infos))

--- a/dags/oss_know/libs/util/base.py
+++ b/dags/oss_know/libs/util/base.py
@@ -16,6 +16,7 @@ from oss_know.libs.base_dict.variable_key import LOCATIONGEO_TOKEN
 from oss_know.libs.util.clickhouse_driver import CKServer
 from oss_know.libs.util.proxy import GithubTokenProxyAccommodator
 from ..util.log import logger
+from oss_know.libs.exceptions import GithubNonExistingUserError
 
 
 class HttpGetException(Exception):
@@ -98,7 +99,7 @@ def do_get_github_result(req_session, url, headers, params, accommodator: Github
             return EmptyResponse()
 
         if res.status_code == 401:
-            # Token no longer invalid
+            # Token becomes invalid
             logger.warning(f'Token {github_token} no longer available, remove it from token list')
             accommodator.report_invalid_token(github_token)
         elif res.status_code == 403:
@@ -108,6 +109,10 @@ def do_get_github_result(req_session, url, headers, params, accommodator: Github
         # TODO The proxy service inside accommodator should provide a unified method to check if the proxy dies
         # elif some_proxy_condition:
         #     token_proxy_accommodator.report_invalid_proxy(proxy_url)
+        elif res.status_code == 404:
+            raise GithubNonExistingUserError(f'Target user not found', res.status_code)
+        else:
+            logger.debug(f"Uncovered status {res.status_code}, text: {res.text}")
 
         raise HttpGetException('http get 失败！', res.status_code)
     return res
@@ -165,15 +170,21 @@ def infer_company_from_emaildomain(email):
     return None
 
 
+_global_geolocator = None
+
+
+def init_geolocator(token):
+    global _global_geolocator
+    if not _global_geolocator:
+        _global_geolocator = GoogleV3(api_key=token)
+
+
 def infer_country_from_location(github_location):
     """
     :param  github_location: location from a GitHub profile
     :return country_name  : the english name of a country
     """
-    from airflow.models import Variable
-    api_token = Variable.get(LOCATIONGEO_TOKEN, deserialize_json=True)
-    geolocator = GoogleV3(api_key=api_token)
-    geo_res = geolocator.geocode(github_location, language='en')
+    geo_res = _global_geolocator.geocode(github_location, language='en')
     if geo_res:
         return geo_res.address.split(',')[-1].strip()
     return None
@@ -184,10 +195,7 @@ def infer_geo_info_from_location(github_location):
     :param  github_location: the location given by github
     :return GoogleGeoInfo  : the information of GoogleGeo inferred by location
     """
-    from airflow.models import Variable
-    api_token = Variable.get(LOCATIONGEO_TOKEN, deserialize_json=True)
-    geolocator = GoogleV3(api_key=api_token)
-    geo_res = geolocator.geocode(github_location, language='en')
+    geo_res = _global_geolocator.geocode(github_location, language='en')
     if geo_res and geo_res.raw and ("address_components" in geo_res.raw) and geo_res.raw["address_components"]:
         address_components = geo_res.raw["address_components"]
         geo_info_from_location = {}

--- a/dags/oss_know/libs/util/base.py
+++ b/dags/oss_know/libs/util/base.py
@@ -16,7 +16,7 @@ from oss_know.libs.base_dict.variable_key import LOCATIONGEO_TOKEN
 from oss_know.libs.util.clickhouse_driver import CKServer
 from oss_know.libs.util.proxy import GithubTokenProxyAccommodator
 from ..util.log import logger
-from oss_know.libs.exceptions import GithubNonExistingUserError
+from oss_know.libs.exceptions import GithubResourceNotFoundError
 
 
 class HttpGetException(Exception):
@@ -110,7 +110,7 @@ def do_get_github_result(req_session, url, headers, params, accommodator: Github
         # elif some_proxy_condition:
         #     token_proxy_accommodator.report_invalid_proxy(proxy_url)
         elif res.status_code == 404:
-            raise GithubNonExistingUserError(f'Target user not found', res.status_code)
+            raise GithubResourceNotFoundError(f'Target github resource {url} not found', res.status_code)
         else:
             logger.debug(f"Uncovered status {res.status_code}, text: {res.text}")
 

--- a/dags/oss_know/libs/util/github_api.py
+++ b/dags/oss_know/libs/util/github_api.py
@@ -1,7 +1,7 @@
 import copy
 
 from oss_know.libs.util.base import do_get_github_result
-from oss_know.libs.exceptions import GithubNonExistingUserError
+from oss_know.libs.exceptions import GithubResourceNotFoundError
 from oss_know.libs.util.log import logger
 
 
@@ -35,7 +35,7 @@ class GithubAPI:
         try:
             req = do_get_github_result(http_session, url, headers, params, accommodator=token_proxy_accommodator)
             latest_github_profile = req.json()
-        except (TypeError, GithubNonExistingUserError) as e:
+        except (TypeError, GithubResourceNotFoundError) as e:
             logger.error(f"Failed to get github profile: {e}, return an empty one")
             return {'login': '', 'id': user_id, 'node_id': '', 'avatar_url': '', 'gravatar_id': '', 'url': '',
                     'html_url': '',

--- a/dags/oss_know/libs/util/opensearch_api.py
+++ b/dags/oss_know/libs/util/opensearch_api.py
@@ -113,7 +113,7 @@ class OpensearchAPI:
 
         return success, failed
 
-    def put_profile_into_opensearch(self, github_ids, github_tokens_iter, opensearch_client):
+    def put_profile_into_opensearch(self, github_ids, token_proxy_accommodator, opensearch_client):
         """Put GitHub user profile into opensearch if it is not in opensearch."""
         # 获取github profile
         for github_id in github_ids:
@@ -142,7 +142,7 @@ class OpensearchAPI:
                 github_api = GithubAPI()
                 session = requests.Session()
                 latest_github_profile = github_api.get_latest_github_profile(http_session=session,
-                                                                             github_tokens_iter=github_tokens_iter,
+                                                                             token_proxy_accommodator=token_proxy_accommodator,
                                                                              user_id=github_id)
                 for tup in inferrers:
                     key, original_key, infer = tup

--- a/dags/oss_know/oss_know_dags/dags_github/dag_github_init_profiles.py
+++ b/dags/oss_know/oss_know_dags/dags_github/dag_github_init_profiles.py
@@ -50,7 +50,7 @@ with DAG(
         from airflow.models import Variable
         from oss_know.libs.util.base import init_geolocator
 
-        geolocator_token = Variable.get(LOCATIONGEO_TOKEN, deserialize_json=Falsez)
+        geolocator_token = Variable.get(LOCATIONGEO_TOKEN, deserialize_json=False)
         init_geolocator(geolocator_token)
 
         github_tokens = Variable.get("github_tokens", deserialize_json=True)

--- a/dags/oss_know/oss_know_dags/dags_github/dag_sync_github_profiles.py
+++ b/dags/oss_know/oss_know_dags/dags_github/dag_sync_github_profiles.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 from oss_know.libs.base_dict.variable_key import OPENSEARCH_CONN_DATA, GITHUB_TOKENS, REDIS_CLIENT_DATA, \
-    DURATION_OF_SYNC_GITHUB_PROFILES,SYNC_PROFILES_TASK_NUM
+    DURATION_OF_SYNC_GITHUB_PROFILES,SYNC_PROFILES_TASK_NUM, LOCATIONGEO_TOKEN,
 from airflow.models import Variable
 
 # v0.0.1
@@ -26,6 +26,9 @@ with DAG(
 
     def do_sync_github_profiles():
         from oss_know.libs.github import sync_profiles
+        from oss_know.libs.util.base import init_geolocator
+        geolocator_token = Variable.get(LOCATIONGEO_TOKEN, deserialize_json=False)
+        init_geolocator(geolocator_token)
 
         github_tokens = Variable.get(GITHUB_TOKENS, deserialize_json=True)
         opensearch_conn_info = Variable.get(OPENSEARCH_CONN_DATA, deserialize_json=True)


### PR DESCRIPTION
Init profiles with proxy, and other fixes:

- Handle non-existing github profile exception
- Remove the dependence on airflow Variable when initializing geolocator
- Store the github id in an accumulated set, instead of converting a big list to set