### PR TITLE
Fix/maillist archive enrich num mismatch

### DIFF
--- a/dags/oss_know/libs/maillist/archive.py
+++ b/dags/oss_know/libs/maillist/archive.py
@@ -197,6 +197,8 @@ def sync_archive(opensearch_conn_info, **maillist_params):
         ocean_backend = MBoxOcean(None)
         enrich_backend = OSSKnowMBoxEnrich(project_name, list_name)
 
+    ocean_backend.set_filter_raw(f'enrich_filter_raw.keyword: {project_name}_{list_name}')
+
     os_user = opensearch_conn_info["USER"]
     os_pass = opensearch_conn_info["PASSWD"]
     os_host = opensearch_conn_info["HOST"]
@@ -261,6 +263,7 @@ def _data2es(items, ocean, project_name, mail_list_name):
             'mail_list_name': mail_list_name,
             'updated_at': now_timestamp()
         }
+        item['data']['enrich_filter_raw'] = f'{project_name}_{mail_list_name}'
         items_pack.append(item)
         if len(items_pack) >= ocean.elastic.max_items_bulk:
             inserted += ocean._items_to_es(items_pack)

--- a/data_schema/variables/variable.json
+++ b/data_schema/variables/variable.json
@@ -1072,7 +1072,7 @@
         },
         "tag": "",
         "data": {
-          "enriched_filter_raw": "pam_pam-list",
+          "enriched_filter_raw": "",
           "unixfrom": "",
           "From": "",
           "Subject": "",
@@ -2332,6 +2332,7 @@
         },
         "tag": "",
         "data": {
+          "enriched_filter_raw": "",
           "unixfrom": "",
           "From": "",
           "Subject": "",

--- a/data_schema/variables/variable.json
+++ b/data_schema/variables/variable.json
@@ -1072,6 +1072,7 @@
         },
         "tag": "",
         "data": {
+          "enriched_filter_raw": "pam_pam-list",
           "unixfrom": "",
           "From": "",
           "Subject": "",


### PR DESCRIPTION
Fix the bug that enriched mailling list items' project name and mail list name don't match the original.

This is caused that when enriching, glab-elk enrich backend tries to fetch original date item by its peering (original) backend, and without passing any filter, it'll go over all the index to fetch item and behave unexpectedly.

This can be solved by adding a filter field to the data item, then data item can be fetched by the (original) backend.