### PR TITLE
Optimize git access and zookeeper performance

### DIFF
--- a/dags/oss_know/libs/github/init_gits.py
+++ b/dags/oss_know/libs/github/init_gits.py
@@ -181,7 +181,8 @@ def init_sync_git_datas(git_url, owner, repo, proxy_config, opensearch_conn_data
     # 实例化opensearchapi
     opensearch_api = OpensearchAPI()
     for commit in repo_iter_commits:
-        files = commit.stats.files
+        commit_stats = commit.stats
+        files = commit_stats.files
         files_list = []
         for file in files:
             file_dict = files[file]
@@ -204,7 +205,7 @@ def init_sync_git_datas(git_url, owner, repo, proxy_config, opensearch_conn_data
         bulk_data["_source"]["raw_data"]["committed_date"] = timestamp_to_utc(commit.committed_datetime.timestamp())
         bulk_data["_source"]["raw_data"]["committed_timestamp"] = commit.committed_date
         bulk_data["_source"]["raw_data"]["files"] = files_list
-        bulk_data["_source"]["raw_data"]["total"] = commit.stats.total
+        bulk_data["_source"]["raw_data"]["total"] = commit_stats.total
         if_merged = False
         if len(bulk_data["_source"]["raw_data"]["parents"]) == 2:
             if_merged = True

--- a/dags/oss_know/libs/maillist/archive.py
+++ b/dags/oss_know/libs/maillist/archive.py
@@ -149,7 +149,7 @@ class GZipArchive(FileArchive):
             remove(gzip_filepath)
 
 
-def sync_archive(opensearch_conn_info, **maillist_params):
+def init_archive(opensearch_conn_info, **maillist_params):
     archive_type = maillist_params['archive_type']
     project_name = maillist_params['project_name']
     list_name = maillist_params['list_name']

--- a/dags/oss_know/oss_know_dags/dags_maillist/dag_init_maillist_archive.py
+++ b/dags/oss_know/oss_know_dags/dags_maillist/dag_init_maillist_archive.py
@@ -9,38 +9,37 @@ from oss_know.libs.base_dict.variable_key import OPENSEARCH_CONN_DATA, MAIL_LIST
 # v0.0.1 It is a mailing list DAG
 
 with DAG(
-        dag_id='init_maillist_archive',
+        dag_id='init_mail_list_archive',
         schedule_interval=None,
         start_date=datetime(2000, 1, 1),
         catchup=False,
         tags=['email'],
 ) as dag:
-    def scheduler_init_sync_maillist(ds, **kwargs):
-        return 'End::scheduler_init_sync_maillist'
+    def scheduler_init_mail_list(ds, **kwargs):
+        return 'End::scheduler_init_mail_list'
 
 
-    op_scheduler_init_sync_maillist = PythonOperator(
-        task_id='scheduler_init_sync_maillist',
-        python_callable=scheduler_init_sync_maillist
+    op_scheduler_init_mail_list = PythonOperator(
+        task_id='scheduler_init_mail_list',
+        python_callable=scheduler_init_mail_list
     )
 
 
-    def do_sync_maillist(params):
-        from oss_know.libs.maillist.archive import sync_archive
+    def do_init_mail_list(params):
+        from oss_know.libs.maillist.archive import init_archive
         opensearch_conn_info = Variable.get(OPENSEARCH_CONN_DATA, deserialize_json=True)
-        sync_archive(opensearch_conn_info, **params)
-        return 'End::sync_maillist'
+        init_archive(opensearch_conn_info, **params)
+        return 'End::init_mail_list'
 
 
-    need_do_inti_sync_ops = []
     mail_lists = Variable.get(MAIL_LISTS, deserialize_json=True)
 
     for mail_list in mail_lists:
         task_name = mail_list["project_name"]
         for mail in mail_list["mail_lists"]:
-            op_do_sync_maillist = PythonOperator(
-                task_id=f'sync_maillist_{mail["list_name"]}',
-                python_callable=do_sync_maillist,
+            op_do_init_mail_list = PythonOperator(
+                task_id=f'init_mail_list_{mail["list_name"]}',
+                python_callable=do_init_mail_list,
                 op_kwargs={'params': dict({"project_name": task_name}.items() | mail.items())},
             )
-            op_scheduler_init_sync_maillist >> op_do_sync_maillist
+            op_scheduler_init_mail_list >> op_do_init_mail_list

--- a/docker/zookeeper/zk1_zoo.cfg
+++ b/docker/zookeeper/zk1_zoo.cfg
@@ -15,6 +15,7 @@ syncLimit=5
 # example sakes.
 ;dataDir=/tmp/zookeeper
 dataDir=/data
+dataLogDir=/datalog
 # the port at which the clients will connect
 clientPort=2181
 

--- a/docker/zookeeper/zk2_zoo.cfg
+++ b/docker/zookeeper/zk2_zoo.cfg
@@ -15,6 +15,7 @@ syncLimit=5
 # example sakes.
 ;dataDir=/tmp/zookeeper
 dataDir=/data
+dataLogDir=/datalog
 # the port at which the clients will connect
 clientPort=2181
 

--- a/docker/zookeeper/zk3_zoo.cfg
+++ b/docker/zookeeper/zk3_zoo.cfg
@@ -15,6 +15,7 @@ syncLimit=5
 # example sakes.
 ;dataDir=/tmp/zookeeper
 dataDir=/data
+dataLogDir=/datalog
 # the port at which the clients will connect
 clientPort=2181
 


### PR DESCRIPTION
- Access GitPython commit instances' `stats` property as less as possible(it's actually a wrapper function which call git command)
- Write zookeeper log and snapshot into different paths 