### PR TITLE
[Feature] Daily sync by parallel groups

### DIFF
--- a/dags/oss_know/libs/util/base.py
+++ b/dags/oss_know/libs/util/base.py
@@ -361,10 +361,13 @@ def arrange_owner_repo_into_letter_groups(owner_repos):
     for letter in ascii_lowercase:
         groups[letter] = []
 
-    for owner_repo_pair in owner_repos:
-        owner, _ = owner_repo_pair
+    for item in owner_repos:
+        if type(item) == tuple:
+            owner, _ = item
+        elif type(item) == dict:
+            owner = item['owner']
         capital_letter = owner[0].lower()
         key = capital_letter if capital_letter in groups else 'other'
-        groups[key].append(owner_repo_pair)
+        groups[key].append(item)
 
     return groups

--- a/dags/oss_know/libs/util/base.py
+++ b/dags/oss_know/libs/util/base.py
@@ -18,6 +18,7 @@ from oss_know.libs.exceptions import GithubResourceNotFoundError, GithubInternal
 from oss_know.libs.util.clickhouse_driver import CKServer
 from oss_know.libs.util.proxy import GithubTokenProxyAccommodator
 from ..util.log import logger
+from string import ascii_lowercase
 
 
 class HttpGetException(Exception):
@@ -350,3 +351,20 @@ def get_clickhouse_client(clickhouse_server_info):
 
 def now_timestamp():
     return int(datetime.now().timestamp() * 1000)
+
+
+# Receive a list of owner repo object, arrange them into groups by owner's capital letter. If capital
+# letter is not ascii char, group key is 'other'
+
+def arrange_owner_repo_into_letter_groups(owner_repos):
+    groups = {'other': []}
+    for letter in ascii_lowercase:
+        groups[letter] = []
+
+    for owner_repo_pair in owner_repos:
+        owner, _ = owner_repo_pair
+        capital_letter = owner[0].lower()
+        key = capital_letter if capital_letter in groups else 'other'
+        groups[key].append(owner_repo_pair)
+
+    return groups

--- a/dags/oss_know/libs/util/data_transfer.py
+++ b/dags/oss_know/libs/util/data_transfer.py
@@ -14,6 +14,16 @@ from oss_know.libs.util.clickhouse_driver import CKServer
 from oss_know.libs.util.log import logger
 
 
+def sync_clickhouse_repos_from_opensearch(owner_repos, index_name, opensearch_conn_info,
+                                          table_name, clickhouse_conn_info, row_template):
+    logger.info(f'Syncing {len(owner_repos)} repos from opensearch to clickhouse')
+    for owner_repo in owner_repos:
+        owner = owner_repo['owner']
+        repo = owner_repo['repo']
+        sync_clickhouse_from_opensearch(owner, repo, index_name, opensearch_conn_info,
+                                        table_name, clickhouse_conn_info, row_template)
+
+
 # Copy the data from opensearch to clickhouse, whose 'updated_at' is greater than the max 'updated_at'
 # in ClickHouse
 def sync_clickhouse_from_opensearch(owner, repo, index_name, opensearch_conn_info,

--- a/dags/oss_know/oss_know_dags/dags_daily_sync/dag_daily_github_commits.py
+++ b/dags/oss_know/oss_know_dags/dags_daily_sync/dag_daily_github_commits.py
@@ -9,8 +9,8 @@ from oss_know.libs.base_dict.variable_key import GITHUB_TOKENS, OPENSEARCH_CONN_
     DAILY_SYNC_GITHUB_COMMITS_EXCLUDES, CLICKHOUSE_DRIVER_INFO, CK_TABLE_DEFAULT_VAL_TPLT, \
     DAILY_SYNC_GITHUB_COMMITS_INCLUDES
 from oss_know.libs.github.sync_commits import sync_github_commits_opensearch
-from oss_know.libs.util.base import get_opensearch_client
-from oss_know.libs.util.data_transfer import sync_clickhouse_from_opensearch
+from oss_know.libs.util.base import get_opensearch_client, arrange_owner_repo_into_letter_groups
+from oss_know.libs.util.data_transfer import sync_clickhouse_repos_from_opensearch
 from oss_know.libs.util.opensearch_api import OpensearchAPI
 from oss_know.libs.util.proxy import KuaiProxyService, ProxyManager, GithubTokenProxyAccommodator
 from oss_know.libs.util.token import TokenManager
@@ -46,16 +46,19 @@ with DAG(dag_id='daily_github_commits_sync',  # schedule_interval='*/5 * * * *',
                                                       policy=GithubTokenProxyAccommodator.POLICY_FIXED_MAP)
 
 
-    def do_sync_github_commits_opensearch(owner, repo):
-        sync_github_commits_opensearch(opensearch_conn_info, owner, repo, proxy_accommodator)
-        return 'do_sync_github_commits:::end'
+    def do_sync_github_commits_opensearch_group(owner_repo_group):
+        for item in owner_repo_group:
+            owner = item['owner']
+            repo = item['repo']
+            sync_github_commits_opensearch(opensearch_conn_info, owner, repo, proxy_accommodator)
+        return 'do_sync_github_commits_opensearch:::end'
 
 
-    def do_sync_github_commits_clickhouse(owner, repo):
-        sync_clickhouse_from_opensearch(owner, repo,
-                                        OPENSEARCH_INDEX_GITHUB_COMMITS, opensearch_conn_info,
-                                        OPENSEARCH_INDEX_GITHUB_COMMITS, clickhouse_conn_info,
-                                        github_commits_table_template)
+    def do_sync_github_commits_clickhouse_group(owner_repo_group):
+        sync_clickhouse_repos_from_opensearch(owner_repo_group,
+                                              OPENSEARCH_INDEX_GITHUB_COMMITS, opensearch_conn_info,
+                                              OPENSEARCH_INDEX_GITHUB_COMMITS, clickhouse_conn_info,
+                                              github_commits_table_template)
 
 
     opensearch_client = get_opensearch_client(opensearch_conn_info=opensearch_conn_info)
@@ -76,23 +79,24 @@ with DAG(dag_id='daily_github_commits_sync',  # schedule_interval='*/5 * * * *',
                 'origin': origin
             })
 
-    for uniq_item in uniq_owner_repos:
-        owner = uniq_item['owner']
-        repo = uniq_item['repo']
-
+    task_groups_by_capital_letter = arrange_owner_repo_into_letter_groups(uniq_owner_repos)
+    # prev_op = op_init_daily_github_commits_sync
+    for letter, owner_repos in task_groups_by_capital_letter.items():
         op_sync_github_commits_opensearch = PythonOperator(
-            task_id=f'do_sync_github_commits_opensearch_{owner}_{repo}',
-            python_callable=do_sync_github_commits_opensearch,
+            task_id=f'op_sync_github_commits_opensearch_group_{letter}',
+            python_callable=do_sync_github_commits_opensearch_group,
+            trigger_rule='all_done',
             op_kwargs={
-                "owner": owner,
-                "repo": repo
-            })
+                "owner_repo_group": owner_repos
+            }
+        )
         op_sync_github_commits_clickhouse = PythonOperator(
-            task_id=f'do_sync_github_commits_clickhouse_{owner}_{repo}',
-            python_callable=do_sync_github_commits_clickhouse,
+            task_id=f'op_sync_github_commits_clickhouse_group_{letter}',
+            python_callable=do_sync_github_commits_clickhouse_group,
+            trigger_rule='all_done',
             op_kwargs={
-                "owner": owner,
-                "repo": repo
-            })
-
+                "owner_repo_group": owner_repos
+            }
+        )
         op_init_daily_github_commits_sync >> op_sync_github_commits_opensearch >> op_sync_github_commits_clickhouse
+        # prev_op = op_sync_github_commits_clickhouse_group

--- a/dags/oss_know/oss_know_dags/dags_daily_sync/dag_daily_gits.py
+++ b/dags/oss_know/oss_know_dags/dags_daily_sync/dag_daily_gits.py
@@ -8,7 +8,7 @@ from oss_know.libs.base_dict.opensearch_index import OPENSEARCH_GIT_RAW
 from oss_know.libs.base_dict.variable_key import DAILY_SYNC_GITS_EXCLUDES, DAILY_SYNC_GITS_INCLUDES, \
     CK_TABLE_DEFAULT_VAL_TPLT, OPENSEARCH_CONN_DATA, CLICKHOUSE_DRIVER_INFO
 from oss_know.libs.github.sync_gits import sync_gits_opensearch
-from oss_know.libs.util.base import get_opensearch_client
+from oss_know.libs.util.base import get_opensearch_client, arrange_owner_repo_into_letter_groups
 from oss_know.libs.util.data_transfer import sync_clickhouse_from_opensearch
 from oss_know.libs.util.opensearch_api import OpensearchAPI
 
@@ -16,6 +16,8 @@ opensearch_conn_info = Variable.get(OPENSEARCH_CONN_DATA, deserialize_json=True)
 clickhouse_conn_info = Variable.get(CLICKHOUSE_DRIVER_INFO, deserialize_json=True)
 table_templates = Variable.get(CK_TABLE_DEFAULT_VAL_TPLT, deserialize_json=True)
 gits_table_template = table_templates.get(OPENSEARCH_GIT_RAW)
+# TODO Put "git_save_local_path" in global const, and change it to string instead of dict
+git_save_local_path = Variable.get("git_save_local_path", deserialize_json=True)
 
 with DAG(dag_id='daily_gits_sync',  # schedule_interval='*/5 * * * *',
          schedule_interval=None, start_date=datetime(2021, 1, 1), catchup=False,
@@ -28,17 +30,22 @@ with DAG(dag_id='daily_gits_sync',  # schedule_interval='*/5 * * * *',
                                              python_callable=op_init_daily_gits_sync, )
 
 
-    def do_sync_git_opensearch(owner, repo, url, proxy_config):
-        opensearch_conn_datas = Variable.get("opensearch_conn_data", deserialize_json=True)
-        git_save_local_path = Variable.get("git_save_local_path", deserialize_json=True)
-        sync_gits_opensearch(url, owner=owner, repo=repo, proxy_config=proxy_config,
-                             opensearch_conn_datas=opensearch_conn_datas, git_save_local_path=git_save_local_path)
+    def do_sync_gits_opensearch_group(owner_repos, proxy_config=None):
+        for item in owner_repos:
+            owner = item['owner']
+            repo = item['repo']
+            url = item['origin']
+            sync_gits_opensearch(url, owner=owner, repo=repo, proxy_config=proxy_config,
+                                 opensearch_conn_datas=opensearch_conn_info, git_save_local_path=git_save_local_path)
         return 'do_sync_gits:::end'
 
 
-    def do_sync_git_clickhouse(owner, repo):
-        sync_clickhouse_from_opensearch(owner, repo, OPENSEARCH_GIT_RAW, opensearch_conn_info,
-                                        OPENSEARCH_GIT_RAW, clickhouse_conn_info, gits_table_template)
+    def do_sync_git_clickhouse_group(owner_repos):
+        for owner_repo in owner_repos:
+            owner = owner_repo['owner']
+            repo = owner_repo['repo']
+            sync_clickhouse_from_opensearch(owner, repo, OPENSEARCH_GIT_RAW, opensearch_conn_info,
+                                            OPENSEARCH_GIT_RAW, clickhouse_conn_info, gits_table_template)
 
 
     opensearch_client = get_opensearch_client(opensearch_conn_info=opensearch_conn_info)
@@ -47,7 +54,7 @@ with DAG(dag_id='daily_gits_sync',  # schedule_interval='*/5 * * * *',
     # Priority:
     # 1. specified included owner_repos
     # 2. all uniq owner repos with specified excludes
-    # 3. all uniq owner repos
+    # 3. all uniq owner repos(if no excludes specified)
     uniq_owner_repos = []
     includes = Variable.get(DAILY_SYNC_GITS_INCLUDES, deserialize_json=True, default_var=None)
     if not includes:
@@ -62,24 +69,31 @@ with DAG(dag_id='daily_gits_sync',  # schedule_interval='*/5 * * * *',
                 'origin': origin
             })
 
-    for uniq_item in uniq_owner_repos:
-        owner = uniq_item['owner']
-        repo = uniq_item['repo']
-        origin = uniq_item['origin']
-
-        op_sync_gits_opensearch = PythonOperator(task_id=f'do_sync_gits_opensearch_{owner}_{repo}',
-                                                 python_callable=do_sync_git_opensearch,
-                                                 op_kwargs={
-                                                     "owner": owner,
-                                                     "repo": repo,
-                                                     "url": origin,
-                                                     "proxy_config": None,
-                                                 })
-        op_sync_gits_clickhouse = PythonOperator(task_id=f'do_sync_gits_clickhouse_{owner}_{repo}',
-                                                 python_callable=do_sync_git_clickhouse,
-                                                 op_kwargs={
-                                                     'owner': owner,
-                                                     'repo': repo,
-                                                 })
-
-        op_init_daily_gits_sync >> op_sync_gits_opensearch >> op_sync_gits_clickhouse
+    task_groups_by_capital_letter = arrange_owner_repo_into_letter_groups(uniq_owner_repos)
+    # TODO Currently the DAG makes 27 parallel task groups(serial execution inside each group)
+    #  Check in production env if it works as expected(won't make too much pressure on opensearch and
+    #  clickhouse. Another approach is to make all groups serial, one after another, which assign
+    #  init_op to prev_op at the beginning, then assign op_sync_gits_clickhouse_group to prev_op
+    #  in each loop iteration(as commented below)
+    #  Another tip: though the groups dict is by default sorted by alphabet, the generated DAG won't
+    #  respect the order
+    # prev_op = op_init_daily_gits_sync
+    for letter, owner_repos in task_groups_by_capital_letter.items():
+        op_sync_gits_opensearch_group = PythonOperator(
+            task_id=f'op_sync_gits_opensearch_group_{letter}',
+            python_callable=do_sync_gits_opensearch_group,
+            trigger_rule='all_done',
+            op_kwargs={
+                "owner_repos": owner_repos
+            }
+        )
+        op_sync_gits_clickhouse_group = PythonOperator(
+            task_id=f'op_sync_gits_clickhouse_group_{letter}',
+            python_callable=do_sync_git_clickhouse_group,
+            trigger_rule='all_done',
+            op_kwargs={
+                "owner_repos": owner_repos
+            }
+        )
+        op_init_daily_gits_sync >> op_sync_gits_opensearch_group >> op_sync_gits_clickhouse_group
+        # prev_op = op_sync_gits_clickhouse_group

--- a/dags/oss_know/oss_know_dags/dags_daily_sync_clickhouse/dag_daily_github_commits_sync_from_clickhouse.py
+++ b/dags/oss_know/oss_know_dags/dags_daily_sync_clickhouse/dag_daily_github_commits_sync_from_clickhouse.py
@@ -8,6 +8,7 @@ from airflow.operators.python import PythonOperator
 from oss_know.libs.base_dict.variable_key import CLICKHOUSE_DRIVER_INFO, SYNC_FROM_CLICKHOUSE_DRIVER_INFO, \
     CLICKHOUSE_SYNC_INTERVAL, CLICKHOUSE_SYNC_COMBINATION_TYPE
 from oss_know.libs.clickhouse.sync_clickhouse_data import sync_from_remote_by_repos, combine_remote_owner_repos
+from oss_know.libs.util.base import arrange_owner_repo_into_letter_groups
 from oss_know.libs.util.log import logger
 
 clickhouse_conn_info = Variable.get(CLICKHOUSE_DRIVER_INFO, deserialize_json=True)
@@ -40,14 +41,7 @@ with DAG(dag_id='daily_github_commits_sync_from_clickhouse',  # schedule_interva
     # Init 26 sub groups by letter(to make the task DAG static)
     # Split all tasks into 26 groups by their capital letter, all tasks inside a group are executed sequentially
     # To avoid to many parallel tasks and keep the DAG static
-    task_groups_by_capital_letter = {}
-    for letter in ascii_lowercase:
-        task_groups_by_capital_letter[letter] = []
-
-    for owner_repo_pair in all_owner_repos:
-        owner, _ = owner_repo_pair
-        task_groups_by_capital_letter[owner[0].lower()].append(owner_repo_pair)
-
+    task_groups_by_capital_letter = arrange_owner_repo_into_letter_groups(all_owner_repos)
     prev_group = None
     for letter, owner_repos in task_groups_by_capital_letter.items():
         op_sync_github_commits_from_clickhouse_group = PythonOperator(

--- a/dags/oss_know/oss_know_dags/dags_daily_sync_clickhouse/dag_daily_github_issue_comments_sync_from_clickhouse.py
+++ b/dags/oss_know/oss_know_dags/dags_daily_sync_clickhouse/dag_daily_github_issue_comments_sync_from_clickhouse.py
@@ -8,6 +8,7 @@ from airflow.operators.python import PythonOperator
 from oss_know.libs.base_dict.variable_key import CLICKHOUSE_DRIVER_INFO, SYNC_FROM_CLICKHOUSE_DRIVER_INFO, \
     CLICKHOUSE_SYNC_INTERVAL, CLICKHOUSE_SYNC_COMBINATION_TYPE
 from oss_know.libs.clickhouse.sync_clickhouse_data import sync_from_remote_by_repos, combine_remote_owner_repos
+from oss_know.libs.util.base import arrange_owner_repo_into_letter_groups
 from oss_know.libs.util.log import logger
 
 clickhouse_conn_info = Variable.get(CLICKHOUSE_DRIVER_INFO, deserialize_json=True)
@@ -42,13 +43,7 @@ with DAG(dag_id='daily_github_issues_comments_sync_from_clickhouse',  # schedule
     # Init 26 sub groups by letter(to make the task DAG static)
     # Split all tasks into 26 groups by their capital letter, all tasks inside a group are executed sequentially
     # To avoid to many parallel tasks and keep the DAG static
-    task_groups_by_capital_letter = {}
-    for letter in ascii_lowercase:
-        task_groups_by_capital_letter[letter] = []
-
-    for owner_repo_pair in all_owner_repos:
-        owner, _ = owner_repo_pair
-        task_groups_by_capital_letter[owner[0].lower()].append(owner_repo_pair)
+    task_groups_by_capital_letter = arrange_owner_repo_into_letter_groups(all_owner_repos)
 
     prev_group = None
     for letter, owner_repos in task_groups_by_capital_letter.items():

--- a/dags/oss_know/oss_know_dags/dags_daily_sync_clickhouse/dag_daily_github_issue_timeline_sync_from_clickhouse.py
+++ b/dags/oss_know/oss_know_dags/dags_daily_sync_clickhouse/dag_daily_github_issue_timeline_sync_from_clickhouse.py
@@ -8,6 +8,7 @@ from airflow.operators.python import PythonOperator
 from oss_know.libs.base_dict.variable_key import CLICKHOUSE_DRIVER_INFO, SYNC_FROM_CLICKHOUSE_DRIVER_INFO, \
     CLICKHOUSE_SYNC_INTERVAL, CLICKHOUSE_SYNC_COMBINATION_TYPE
 from oss_know.libs.clickhouse.sync_clickhouse_data import sync_from_remote_by_repos, combine_remote_owner_repos
+from oss_know.libs.util.base import arrange_owner_repo_into_letter_groups
 from oss_know.libs.util.log import logger
 
 clickhouse_conn_info = Variable.get(CLICKHOUSE_DRIVER_INFO, deserialize_json=True)
@@ -43,13 +44,7 @@ with DAG(dag_id='daily_github_issues_timeline_sync_from_clickhouse',  # schedule
     # Init 26 sub groups by letter(to make the task DAG static)
     # Split all tasks into 26 groups by their capital letter, all tasks inside a group are executed sequentially
     # To avoid to many parallel tasks and keep the DAG static
-    task_groups_by_capital_letter = {}
-    for letter in ascii_lowercase:
-        task_groups_by_capital_letter[letter] = []
-
-    for owner_repo_pair in all_owner_repos:
-        owner, _ = owner_repo_pair
-        task_groups_by_capital_letter[owner[0].lower()].append(owner_repo_pair)
+    task_groups_by_capital_letter = arrange_owner_repo_into_letter_groups(all_owner_repos)
 
     prev_group = None
     for letter, owner_repos in task_groups_by_capital_letter.items():

--- a/dags/oss_know/oss_know_dags/dags_daily_sync_clickhouse/dag_daily_github_issues_sync_from_clickhouse.py
+++ b/dags/oss_know/oss_know_dags/dags_daily_sync_clickhouse/dag_daily_github_issues_sync_from_clickhouse.py
@@ -41,13 +41,15 @@ with DAG(dag_id='daily_github_issues_sync_from_clickhouse',  # schedule_interval
     # Init 26 sub groups by letter(to make the task DAG static)
     # Split all tasks into 26 groups by their capital letter, all tasks inside a group are executed sequentially
     # To avoid to many parallel tasks and keep the DAG static
-    task_groups_by_capital_letter = {}
+    task_groups_by_capital_letter = {'other': []}
     for letter in ascii_lowercase:
         task_groups_by_capital_letter[letter] = []
 
     for owner_repo_pair in all_owner_repos:
         owner, _ = owner_repo_pair
-        task_groups_by_capital_letter[owner[0].lower()].append(owner_repo_pair)
+        capital_letter = owner[0].lower()
+        key = capital_letter if capital_letter in task_groups_by_capital_letter else 'other'
+        task_groups_by_capital_letter[key].append(owner_repo_pair)
 
     prev_group = None
     for letter, owner_repos in task_groups_by_capital_letter.items():

--- a/dags/oss_know/oss_know_dags/dags_daily_sync_clickhouse/dag_daily_gits_sync_from_clickhouse.py
+++ b/dags/oss_know/oss_know_dags/dags_daily_sync_clickhouse/dag_daily_gits_sync_from_clickhouse.py
@@ -8,6 +8,7 @@ from airflow.operators.python import PythonOperator
 from oss_know.libs.base_dict.variable_key import CLICKHOUSE_DRIVER_INFO, SYNC_FROM_CLICKHOUSE_DRIVER_INFO, \
     CLICKHOUSE_SYNC_INTERVAL, CLICKHOUSE_SYNC_COMBINATION_TYPE
 from oss_know.libs.clickhouse.sync_clickhouse_data import sync_from_remote_by_repos, combine_remote_owner_repos
+from oss_know.libs.util.base import arrange_owner_repo_into_letter_groups
 from oss_know.libs.util.log import logger
 
 clickhouse_conn_info = Variable.get(CLICKHOUSE_DRIVER_INFO, deserialize_json=True)
@@ -41,14 +42,7 @@ with DAG(dag_id='daily_gits_sync_from_clickhouse',  # schedule_interval='*/5 * *
     # Init 26 sub groups by letter(to make the task DAG static)
     # Split all tasks into 26 groups by their capital letter, all tasks inside a group are executed sequentially
     # To avoid to many parallel tasks and keep the DAG static
-    task_groups_by_capital_letter = {}
-    for letter in ascii_lowercase:
-        task_groups_by_capital_letter[letter] = []
-
-    for owner_repo_pair in all_owner_repos:
-        owner, _ = owner_repo_pair
-        task_groups_by_capital_letter[owner[0].lower()].append(owner_repo_pair)
-
+    task_groups_by_capital_letter = arrange_owner_repo_into_letter_groups(all_owner_repos)
     prev_group = None
     for letter, owner_repos in task_groups_by_capital_letter.items():
         op_sync_gits_from_clickhouse_group = PythonOperator(


### PR DESCRIPTION
- Extract the util to arrange daily sync tasks by the capital letter of code repo's 'owner', into 27 groups with 26 ascii lowercase and 'other' as the keys.
- Apply the util above to both DAGs of daily sync / daily sync from clickhouse.