### PR TITLE
Update the airflow version to 2.5.2(py3.8) in Dockerfile.

### DIFF
--- a/docker/airflow/Dockerfile-2.2.3-python3.8
+++ b/docker/airflow/Dockerfile-2.2.3-python3.8
@@ -1,11 +1,10 @@
-FROM apache/airflow:2.5.2-python3.8
+FROM apache/airflow:2.2.3-python3.8
 
 ENV DEBIAN_FRONTEND noninteractive
 
 USER root
 RUN sudo apt-get update && sudo ACCEPT_EULA=Y apt-get upgrade -y -q --assume-yes
 RUN sudo apt-get install git gcc -y -q
-RUN sudo apt-get install libmysqlclient-dev -y
 
 USER airflow
 RUN /usr/local/bin/python -m pip install --upgrade pip
@@ -26,4 +25,3 @@ RUN pip install --no-cache-dir  'loguru>=0.5.3' \
 RUN pip install --no-cache-dir 'apache-airflow[password]==2.2.3'
 RUN pip install --no-cache-dir 'multidict==5.2.0'
 
-RUN pip install markupsafe==2.0.1


### PR DESCRIPTION
Add the constraint of markupsafe version to 2.0.1, according to the ref: https://github.com/aws/aws-sam-cli/issues/3661#issuecomment-1044340547

Add a snapshot of version 2.2.3's Dockerfile