### PR TITLE
Restructure/multithreading

### DIFF
--- a/dags/oss_know/libs/github/init_profiles.py
+++ b/dags/oss_know/libs/github/init_profiles.py
@@ -98,11 +98,13 @@ def get_profiles_from_os(opensearch_client, owner, repo, index):
     return res
 
 
-def load_github_profiles(token_proxy_accommodator, opensearch_conn_infos, github_users_ids, if_sync, if_new_person):
+def load_github_profiles(token_proxy_accommodator, opensearch_conn_info, github_users_ids, if_sync, if_new_person):
     """Get GitHub profiles by ids."""
     # get ids set;
     # github_users_ids = list(set(github_users_ids))
     # put GitHub user profile into opensearch if it is not in opensearch
     opensearch_api = OpensearchAPI()
-    opensearch_api.put_profile_into_opensearch(github_ids=github_users_ids, token_proxy_accommodator=token_proxy_accommodator,
-                                               opensearch_client=get_opensearch_client(opensearch_conn_infos), if_sync=if_sync, if_new_person=if_new_person)
+    opensearch_api.put_profile_into_opensearch(github_ids=github_users_ids,
+                                               token_proxy_accommodator=token_proxy_accommodator,
+                                               opensearch_client=get_opensearch_client(opensearch_conn_info),
+                                               if_sync=if_sync, if_new_person=if_new_person)

--- a/dags/oss_know/libs/util/github_api.py
+++ b/dags/oss_know/libs/util/github_api.py
@@ -67,7 +67,6 @@ class GithubAPI:
                     'final_company_inferred_from_company': '',
                     'company_inferred_from_email_domain_company': '', 'inferred_from_location': ''}
         else:
-            logger.info(f"Get GitHub {user_id}'s latest profile from GitHUb.")
             return latest_github_profile
 
     def get_github_issues_timeline(self, http_session, token_proxy_accommodator, owner, repo, number, page):

--- a/dags/oss_know/libs/util/opensearch_api.py
+++ b/dags/oss_know/libs/util/opensearch_api.py
@@ -141,7 +141,6 @@ class OpensearchAPI:
             task_futures = []
             num_finished = 0
             for index, github_id in enumerate(github_ids):
-                logger.info(f'github_profile_user:{github_id}')
                 time.sleep(round(random.uniform(0.01, 0.1), 2))
                 task_futures.append(
                     executor.submit(self.do_init_github_profile, github_id, opensearch_client,
@@ -189,7 +188,7 @@ class OpensearchAPI:
             opensearch_client.index(index=OPENSEARCH_INDEX_GITHUB_PROFILE,
                                     body={
                                         "search_key": {
-                                            'updated_at': now_timestamp,
+                                            'updated_at': now_timestamp(),
                                             'if_sync': if_sync,
                                             'if_new_person': if_new_person
                                         },

--- a/dags/oss_know/libs/util/opensearch_api.py
+++ b/dags/oss_know/libs/util/opensearch_api.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import random
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Tuple
 
 import dateutil
@@ -18,9 +19,8 @@ from oss_know.libs.base_dict.opensearch_index import OPENSEARCH_INDEX_GITHUB_COM
     OPENSEARCH_INDEX_GITHUB_ISSUES_TIMELINE, OPENSEARCH_INDEX_GITHUB_ISSUES_COMMENTS, \
     OPENSEARCH_INDEX_CHECK_SYNC_DATA, OPENSEARCH_INDEX_GITHUB_PROFILE, OPENSEARCH_INDEX_GITHUB_PULL_REQUESTS
 from oss_know.libs.util.airflow import get_postgres_conn
-from oss_know.libs.util.base import infer_country_company_geo_insert_into_profile, inferrers, concurrent_threads, \
-    now_timestamp
-from oss_know.libs.util.github_api import GithubAPI, GithubException
+from oss_know.libs.util.base import infer_country_company_geo_insert_into_profile, inferrers, now_timestamp
+from oss_know.libs.util.github_api import GithubAPI
 from oss_know.libs.util.log import logger
 
 
@@ -137,39 +137,27 @@ class OpensearchAPI:
         batch_size = 100
         num_github_ids = len(github_ids)
 
-        get_comment_tasks = list()
-        get_comment_results = list()
-        get_comment_fails_results = list()
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            task_futures = []
+            num_finished = 0
+            for index, github_id in enumerate(github_ids):
+                logger.info(f'github_profile_user:{github_id}')
+                time.sleep(round(random.uniform(0.01, 0.1), 2))
+                task_futures.append(
+                    executor.submit(self.do_init_github_profile, github_id, opensearch_client,
+                                    token_proxy_accommodator, if_sync, if_new_person))
 
-        for index, github_id in enumerate(github_ids):
-            logger.info(f'github_profile_user:{github_id}')
-            time.sleep(round(random.uniform(0.01, 0.1), 2))
+            for future in as_completed(task_futures):
+                future.result()
+                num_finished += 1
 
-            # 创建并发任务
-            ct = concurrent_threads(self.do_init_github_profile_thread,
-                                    args=(batch_size, github_id, index, num_github_ids, opensearch_client,
-                                          token_proxy_accommodator, if_sync, if_new_person))
-            get_comment_tasks.append(ct)
-            ct.start()
-            ct.join()
-            # 执行并发任务并获取结果
-            if index % 50 == 0:
-                for tt in get_comment_tasks:
-                    if tt.getResult()[0] != 200:
-                        logger.info(f"get_timeline_fails_results:{tt},{tt.args}")
-                        get_comment_fails_results.append(tt.getResult())
-
-                    get_comment_results.append(tt.getResult())
-            if len(get_comment_fails_results) != 0:
-                raise GithubException('github请求失败！', get_comment_fails_results)
-
-            # self.do_init_github_profile_thread(batch_size, github_id, index, num_github_ids, opensearch_client,
-            #                                    token_proxy_accommodator)
-        logger.info(f'{num_github_ids} github profiles finished')
+                if num_finished % batch_size == 0:
+                    logger.info(f'{num_finished} / {num_github_ids} profiles initialized')
+        logger.info(f'{num_finished} github profiles finished')
         return "Put GitHub user profile into opensearch if it is not in opensearch"
 
-    def do_init_github_profile_thread(self, batch_size, github_id, index, num_github_ids, opensearch_client,
-                                      token_proxy_accommodator, if_sync, if_new_person):
+    def do_init_github_profile(self, github_id, opensearch_client,
+                               token_proxy_accommodator, if_sync, if_new_person):
         has_user_profile = opensearch_client.search(index=OPENSEARCH_INDEX_GITHUB_PROFILE,
                                                     body={
                                                         "query": {
@@ -201,7 +189,7 @@ class OpensearchAPI:
             opensearch_client.index(index=OPENSEARCH_INDEX_GITHUB_PROFILE,
                                     body={
                                         "search_key": {
-                                            'updated_at': int(datetime.datetime.now().timestamp() * 1000),
+                                            'updated_at': now_timestamp,
                                             'if_sync': if_sync,
                                             'if_new_person': if_new_person
                                         },
@@ -211,10 +199,6 @@ class OpensearchAPI:
             logger.info(f"Put the github {github_id}'s profile into opensearch.")
         else:
             logger.info(f"{github_id}'s profile has already existed.")
-        if index % batch_size == 0:
-            logger.info(f'{index}/{num_github_ids} finished')
-
-        return 200, f"success init github profile, github_id:{github_id}, end"
 
     def bulk_github_issues_timeline(self, opensearch_client, issues_timelines, owner, repo, number, if_sync):
         bulk_all_datas = []

--- a/dags/oss_know/oss_know_dags/dag_analysis_reports/dag_init_get_middle_table.py
+++ b/dags/oss_know/oss_know_dags/dag_analysis_reports/dag_init_get_middle_table.py
@@ -2,17 +2,18 @@
 import random
 import time
 from datetime import datetime
+
 from airflow import DAG
+from airflow.models import Variable
 from airflow.operators.python import PythonOperator
 
 from oss_know.libs.analysis_report.email_tz_region_map import get_email_tz_region_map
 from oss_know.libs.analysis_report.github_id_email_map import get_github_id_email_map
 from oss_know.libs.analysis_report.github_id_tz_region_map import get_github_id_tz_region_map
 from oss_know.libs.analysis_report.timeline_approved_reviewed import get_github_id_approved_reviewed
-from oss_know.libs.util.log import logger
 # git_init_sync_v0.0.3
-from oss_know.libs.analysis_report.init_get_dir2_contribute_data_v1 import get_dir2_contribute_data
 from oss_know.libs.base_dict.variable_key import CLICKHOUSE_DRIVER_INFO
+from oss_know.libs.util.log import logger
 
 with DAG(
         dag_id='dag_init_get_middle_table',
@@ -32,7 +33,6 @@ with DAG(
 
 
     def do_get_email_tz_region_map():
-        from airflow.models import Variable
         clickhouse_server_info = Variable.get(CLICKHOUSE_DRIVER_INFO, deserialize_json=True)
         wait_time = random.randint(1, 60)
         logger.info(f"等待{wait_time} s ...")
@@ -42,7 +42,6 @@ with DAG(
 
 
     def do_get_github_id_tz_region_map():
-        from airflow.models import Variable
         wait_time = random.randint(1, 60)
         logger.info(f"等待{wait_time} s ...")
         time.sleep(wait_time)
@@ -51,15 +50,14 @@ with DAG(
 
 
     def do_get_github_id_approved_reviewed():
-        from airflow.models import Variable
         wait_time = random.randint(1, 60)
         logger.info(f"等待{wait_time} s ...")
         time.sleep(wait_time)
         clickhouse_server_info = Variable.get(CLICKHOUSE_DRIVER_INFO, deserialize_json=True)
         get_github_id_approved_reviewed(clickhouse_server_info)
 
+
     def do_get_github_id_email_map():
-        from airflow.models import Variable
         wait_time = random.randint(1, 60)
         logger.info(f"等待{wait_time} s ...")
         time.sleep(wait_time)

--- a/dags/oss_know/oss_know_dags/dags_github/dag_github_sync_profiles_v2.py
+++ b/dags/oss_know/oss_know_dags/dags_github/dag_github_sync_profiles_v2.py
@@ -69,7 +69,7 @@ with DAG(
 
         if_sync, if_new_person = 1, 1
         init_profiles.load_github_profiles(token_proxy_accommodator=proxy_accommodator,
-                                           opensearch_conn_infos=opensearch_conn_info,
+                                           opensearch_conn_info=opensearch_conn_info,
                                            github_users_ids=github_users_ids, if_sync=if_sync,
                                            if_new_person=if_new_person)
         return 'End load_github_repo_profile'


### PR DESCRIPTION
Use `ThreadPoolExecutor` to init GitHub profiles in a parallel way, resolving #179 