### PR TITLE
Replace pandas.core.Series.iteritems with items()

### DIFF
--- a/dags/oss_know/libs/clickhouse/ck_alter_table.py
+++ b/dags/oss_know/libs/clickhouse/ck_alter_table.py
@@ -15,7 +15,7 @@ def create_ck_table(df,
     all_fields = {}
     ck_data_type = []
     # 确定每个字段的类型 然后建表
-    for index, row in df.iloc[0].iteritems():
+    for index, row in df.iloc[0].items():
         # 去除包含raw_data的前缀
         if index.startswith('raw_data'):
             index = index[9:]
@@ -68,7 +68,10 @@ def create_ck_table(df,
         else:
             field_delete.append(key)
     for key in all_fields:
-        sql = f'ALTER TABLE {database_name}.{table_name}_local ON CLUSTER {cluster_name} ADD COLUMN {key} {all_fields.get(key)};'
+        sql = f'''
+        ALTER TABLE {database_name}.{table_name}_local ON CLUSTER {cluster_name}
+        ADD COLUMN {key} {all_fields.get(key)};
+        '''
         ck.execute_no_params(sql)
         logger.info(f'执行的sql语句: {sql}')
 
@@ -77,13 +80,19 @@ def create_ck_table(df,
         ck.execute_no_params(sql)
         logger.info(f'执行的sql语句: {sql}')
     for key in field_change:
-        sql = f'ALTER TABLE {database_name}.{table_name}_local ON CLUSTER {cluster_name} MODIFY COLUMN IF EXISTS {key} {field_change.get(key)}'
+        sql = f'''
+        ALTER TABLE {database_name}.{table_name}_local ON CLUSTER {cluster_name} MODIFY COLUMN IF EXISTS
+        {key} {field_change.get(key)}
+        '''
         ck.execute_no_params(sql)
         logger.info(f'执行的sql语句: {sql}')
 
     sql = f'DROP TABLE {database_name}.{table_name} ON CLUSTER {cluster_name}'
     ck.execute_no_params(sql)
-    sql = f'CREATE TABLE {database_name}.{table_name} ON CLUSTER {cluster_name} AS {database_name}.{table_name}_local Engine= Distributed({cluster_name},{database_name},{table_name}_local,{distributed_key});'
+    sql = f'''
+    CREATE TABLE {database_name}.{table_name} ON CLUSTER {cluster_name} AS {database_name}.{table_name}_local
+    Engine= Distributed({cluster_name},{database_name},{table_name}_local,{distributed_key});
+    '''
     ck.execute_no_params(sql)
     ck.close()
 

--- a/dags/oss_know/libs/clickhouse/ck_create_table.py
+++ b/dags/oss_know/libs/clickhouse/ck_create_table.py
@@ -41,7 +41,7 @@ def create_ck_table(df,
     # 存储最终的字段
     ck_data_type = []
     # 确定每个字段的类型 然后建表
-    for index, row in df.iloc[0].iteritems():
+    for index, row in df.iloc[0].items():
         # 去除包含raw_data的前缀
         if index.startswith('raw_data'):
             index = index[9:]
@@ -80,8 +80,15 @@ def create_ck_table(df,
 
         ck_data_type.append(data_type_outer)
     result = ",\r\n".join(ck_data_type)
-    create_local_table_ddl = f'CREATE TABLE IF NOT EXISTS {database_name}.{table_name}_local on cluster {cluster_name}({result}) Engine={table_engine}'
-    create_distributed_ddl = f'CREATE TABLE IF NOT EXISTS {database_name}.{table_name} on cluster {cluster_name} as {database_name}.{table_name}_local Engine= Distributed({cluster_name},{database_name},{table_name}_local,{distributed_key})'
+    create_local_table_ddl = f'''
+    CREATE TABLE IF NOT EXISTS {database_name}.{table_name}_local
+    on cluster {cluster_name}({result}) Engine={table_engine}
+    '''
+    create_distributed_ddl = f'''
+    CREATE TABLE IF NOT EXISTS {database_name}.{table_name}
+    on cluster {cluster_name} as {database_name}.{table_name}_local
+    Engine= Distributed({cluster_name},{database_name},{table_name}_local,{distributed_key})
+    '''
     if partition_by:
         create_local_table_ddl = f'{create_local_table_ddl} PARTITION BY {partition_by}'
     if order_by:

--- a/dags/oss_know/libs/clickhouse/init_ck_transfer_data.py
+++ b/dags/oss_know/libs/clickhouse/init_ck_transfer_data.py
@@ -348,7 +348,7 @@ def transfer_data_by_repo(clickhouse_server_info, table_name, opensearch_index, 
 # def parse_data(df, temp):
 #     # 这个是最终插入ck的数据字典
 #     dict_data = copy.deepcopy(temp)
-#     for index, row in df.iloc[0].iteritems():
+#     for index, row in df.iloc[0].items():
 #         # 去除以raw_data开头的字段
 #         if index.startswith("raw"):
 #             index = index[9:]


### PR DESCRIPTION
Use f''' strings to replace multiple single line f strings in long SQL delcarations, make the SQLs more human readable.

Cautious! This change might not work since there are super long string value checks on 'command' column in clickhouse system table. The clickhouse SQL parser "should" handle the newlines but currnetly it's not fully tested(on our side, not clickhouse side)